### PR TITLE
Fixed the optional eventValue parameter.

### DIFF
--- a/Universal-Federated-Analytics-Min.js
+++ b/Universal-Federated-Analytics-Min.js
@@ -89,7 +89,7 @@ else if(_hitType.toLowerCase()=='event'&&_param2!=undefined&&_param2!='')
 {_param5=_nonInteraction;}
 else
 {_nonInteraction=_cleanBooleanParam(_param5);}
-_sendEvent(_param1,_param2,((_param3!=undefined)?_param3:''),((_param4!=''||!isNaN(_param4)||_param4!=undefined)?parseInt(_param4):0),((_nonInteraction=='true')?1:0));}
+_sendEvent(_param1,_param2,((_param3!=undefined)?_param3:''),((_param4==''||isNaN(_param4)||_param4==undefined)?0:parseInt(_param4)),((_nonInteraction=='true')?1:0));}
 catch(err)
 {}}
 else if(_hitType.toLowerCase().indexOf('dimension')!=-1)

--- a/Universal-Federated-Analytics.js
+++ b/Universal-Federated-Analytics.js
@@ -395,7 +395,7 @@ function gas(_command, _hitType, _param1, _param2, _param3, _param4, _param5)
 				{
 					_nonInteraction = _cleanBooleanParam(_param5);
 				}
-				_sendEvent(_param1, _param2, ((_param3 != undefined) ? _param3 : ''), ((_param4 != '' || !isNaN(_param4) || _param4 != undefined) ? parseInt(_param4) : 0), ((_nonInteraction == 'true') ? 1 : 0));
+				_sendEvent(_param1, _param2, ((_param3 != undefined) ? _param3 : ''), ((_param4 == '' || isNaN(_param4) || _param4 == undefined) ? 0 : parseInt(_param4)), ((_nonInteraction == 'true') ? 1 : 0));
 			}
 			catch(err) 
 			{


### PR DESCRIPTION
**The Problem:**
  Event transactions were being ignored by Google Analytics.

**The Cause:**
  Using Google Analytics Debugger (Google Chrome Browser Extension), we determined that the value NaN sent to Google Analytics causing a JavaScript warning.

  When the fourth parameter (eventValue) is undefined, which is then passed as NaN into _sendEvent (eventValue), where it is eventually passed into ga function.  This function expected eventValue to only be a number.

  The JavaScript warning is "Expected a number value for the field: "eventValue", but found: "number".

**The Solution:**
  The changes to the _sendEvent line correctly identify when the parameter is undefined and will pass 0 to the function, insuring that only a number is passed to Google Analytics.  I updated the fourth parameter on the gas function for events.

**Testing:**
  Use the following JavaScript function call in order to test. Observe the results on the console, where Google Analytics Debugger provides results"

  If you are not using the debugger, look for "ev: NaN" under collect?... in your browsers Network log.  Select "collect?...." and look under "Query String Parameters"

  `gas('send', 'event', 'test-category', 'test-action', 'test-label');`
