### PR TITLE
Allow _initAutoTracker() to take a NodeList

### DIFF
--- a/Universal-Federated-Analytics.js
+++ b/Universal-Federated-Analytics.js
@@ -609,11 +609,11 @@ function createTracker(sendPv)
  * name: _initAutoTracker
  * usage: to automatically tag outbound links / e-mails / downloads
  */
-function _initAutoTracker()
+function _initAutoTracker(links)
 {
 	var mainDomain = oCONFIG.COOKIE_DOMAIN;
 	var extDoc = oCONFIG.EXTS.split("|");
-	var arr = document.getElementsByTagName("a");
+	var arr = links || document.getElementsByTagName("a");
 	for(i=0; i < arr.length; i++)
 	 {
 		var flag = 0;


### PR DESCRIPTION
This is an example of a simple workaround for the problem described in https://github.com/digital-analytics-program/gov-wide-code/pull/47#issuecomment-253232382, whereby calling `_initAutoTracker()` every time new links are added to a page will result in pre-existing links being tracked _multiple times_ upon being clicked.

It preserves backwards compatibility by allowing `_initAutoTracker()` to be called without any arguments; but if a `NodeList` is passed in, it will be used instead of the set of all links on the page. This allows client libraries to only pass it links that it knows the auto tracker doesn't know about.
