### PR TITLE
Change condition so that "currentId == undefined" does not always evaluate to "false"

### DIFF
--- a/Universal-Federated-Analytics.js
+++ b/Universal-Federated-Analytics.js
@@ -904,7 +904,7 @@ function _initIdAssigner() {
     var _allDocLinks = document.getElementsByTagName('a');
     for (var sid = 0; sid < _allDocLinks.length; sid++) {
         var currentId = _allDocLinks[sid].getAttribute('id');
-        if (currentId == null || currentId == '' || currentId == undefined) {
+        if (currentId === null || currentId === '' || currentId === undefined) {
             _allDocLinks[sid].setAttribute('id', 'anch_' + sid);
         }
     }


### PR DESCRIPTION

Noticed that currentId == undefined was always evaluating to false, so updated the condition to address that.