### PR TITLE
Add option to skip sending the initial pageview

### DIFF
--- a/Universal-Federated-Analytics.js
+++ b/Universal-Federated-Analytics.js
@@ -52,6 +52,7 @@ var oCONFIG = {
     DOUNBLECLICK_LINK: false,
     ENHANCED_LINK: false,
     OPTOUT_PAGE: false,
+    SEND_PAGEVIEW: true,
     PUA_NAME: 'GSA_ENOR'
 };
 
@@ -272,6 +273,12 @@ function _updateConfig() {
                 if (true == _value || false == _value)  
                     oCONFIG.OPTOUT_PAGE = _value;
                 break;
+            case 'sendpageview':
+                _value = _cleanBooleanParam(_value);
+                if (true == _value || false == _value)
+                    oCONFIG.SEND_PAGEVIEW = _value;
+                break;
+
 			default:
 				break;
         }
@@ -543,7 +550,7 @@ else
 }
 
 /* create the trackers according to oCONFIG object and fire the main pageview */
-createTracker(true);
+createTracker(oCONFIG.SEND_PAGEVIEW);
 
 function createTracker(sendPv)
 {


### PR DESCRIPTION
This adds a `sendpageview` option to the URL parameters, which defaults to `true` (the current behavior, so this shouldn't change existing usage), but can be set to `false` to skip sending the initial `pageview` command to Google Analytics on page load.

The use-case I have for this is in dealing with integrating DAP with some single-page JavaScript apps where I'm also wanting to send virtual pageviews (similar to https://github.com/digital-analytics-program/gov-wide-code/issues/59). The problem is that the simplest ways to integrate virtual page views in these type of apps may lead to double counting the initial pageview, since DAP always sends a pageview, and these type of javascript routers may also send a virtual pageview on load. While there are ways to workaround this within the applications, having something like this type of toggle might be handy. This way you can opt-out of DAP's initial pageview if you know you only want to be performing virtual pageviews within your own application.

Give a shout if you have any questions or comments. Thanks!