### PR TITLE
include package.json with build script to ensure a consistent environments and build process across teams

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,0 +1,22 @@
+{
+  "name": "digital-analytics-program",
+  "version": "4.0.0",
+  "description": "Provides a JavaScript file for US federal agencies to link or embed in their websites to participate in the Digital Analytics Program.",
+  "main": "Universal-Federated-Analytics.js",
+  "scripts": {
+    "build": "npx uglifyjs Universal-Federated-Analytics.js --output Universal-Federated-Analytics-Min.js",
+    "clean": "rm ./Universal-Federated-Analytics-Min.js"
+  },
+  "repository": {
+    "type": "git",
+    "url": "git+https://github.com/digital-analytics-program/gov-wide-code.git"
+  },
+  "license": "ISC",
+  "bugs": {
+    "url": "https://github.com/digital-analytics-program/gov-wide-code/issues"
+  },
+  "homepage": "https://github.com/digital-analytics-program/gov-wide-code#readme",
+  "dependencies": {
+    "uglify-js": "^3.4.9"
+  }
+}


### PR DESCRIPTION
The environment and build process are currently unclear and not documented anywhere.  Adding a package.json brings a bit more structure to how releases are built and managed. This is just the start, but will be especially useful for future teams.