### PR TITLE
document.head

### DIFF
--- a/Universal-Federated-Analytics.js
+++ b/Universal-Federated-Analytics.js
@@ -64,7 +64,7 @@ var tObjectCheck,
   _setEnvironment();
 
 //*********GA4************
-var head = document.getElementsByTagName("head").item(0);
+var head = document.head;
 var GA4Object = document.createElement("script");
 GA4Object.setAttribute("type", "text/javascript");
 GA4Object.setAttribute(


### PR DESCRIPTION
Not supported in browsers like Internet Explorer 8 and earlier, but it is available in IE9+ and modern browsers

## Additional reference:

https://designsystem.digital.gov/documentation/developers/#browser-support-2