### PR TITLE
Add a SECURITY.md file.

### DIFF
--- a/SECURITY.md
+++ b/SECURITY.md
@@ -1,31 +1,29 @@
 # Security Policy
 
-As a U.S. Government agency, the General Services Administration (GSA) takes
-seriously our responsibility to protect the public's information, including
-financial and personal information, from unwarranted disclosure.
-
-## Reporting a Vulnerability
-
 Services operated by the U.S. General Services Administration (GSA)
 are covered by the **GSA Vulnerability Disclosure Program (VDP)**.
 
-See the [GSA Vulnerability Disclosure Policy](https://gsa.gov/vulnerability-disclosure-policy)
-at <https://www.gsa.gov/vulnerability-disclosure-policy> for details including:
+See the [GSA Vulnerability Disclosure Policy](https://gsa.gov/vulnerability-disclosure-policy) for details including:
 
-* How to submit a report if you believe you have discovered a vulnerability.
 * GSA's coordinated disclosure policy.
 * Information on how you may conduct security research on GSA developed
   software and systems.
 * Important legal and policy guidance.
 
+## Reporting a Vulnerability
+
+Security issues should be reported via GitHub [private vulnerability reporting](https://docs.github.com/en/code-security/security-advisories/guidance-on-reporting-and-writing-information-about-vulnerabilities/privately-reporting-a-security-vulnerability#privately-reporting-a-security-vulnerability) (requires a GitHub account) or by sending an email to dap@gsa.gov.
+
+Security issues may also be reported to the GSA Vulnerability Disclosure Program, following instructions in the policy linked above. However, we ask that you report directly to us as well, to ensure that the issue will be reviewed quickly.
+
 ## Supported Versions
 
-Please note that only certain released versions are supported with security updates.
+Please note that only the most recent major version of the DAP code is supported with security updates.
 
 | Version | Supported          |
-|---------| ------------------ |
-| 8.x.x   | :white_check_mark: |
-| < 8.0   | :x:                |
+|-------| ------------------ |
+| 8.x   | :white_check_mark: |
+| < 8.0 | :x:                |
 
 When using this code or reporting vulnerabilities please only use supported
 versions.

--- a/SECURITY.md
+++ b/SECURITY.md
@@ -1,0 +1,31 @@
+# Security Policy
+
+As a U.S. Government agency, the General Services Administration (GSA) takes
+seriously our responsibility to protect the public's information, including
+financial and personal information, from unwarranted disclosure.
+
+## Reporting a Vulnerability
+
+Services operated by the U.S. General Services Administration (GSA)
+are covered by the **GSA Vulnerability Disclosure Program (VDP)**.
+
+See the [GSA Vulnerability Disclosure Policy](https://gsa.gov/vulnerability-disclosure-policy)
+at <https://www.gsa.gov/vulnerability-disclosure-policy> for details including:
+
+* How to submit a report if you believe you have discovered a vulnerability.
+* GSA's coordinated disclosure policy.
+* Information on how you may conduct security research on GSA developed
+  software and systems.
+* Important legal and policy guidance.
+
+## Supported Versions
+
+Please note that only certain released versions are supported with security updates.
+
+| Version | Supported          |
+|---------| ------------------ |
+| 8.x.x   | :white_check_mark: |
+| < 8.0   | :x:                |
+
+When using this code or reporting vulnerabilities please only use supported
+versions.

--- a/SECURITY.md
+++ b/SECURITY.md
@@ -1,9 +1,7 @@
 # Security Policy
 
 Services operated by the U.S. General Services Administration (GSA)
-are covered by the **GSA Vulnerability Disclosure Program (VDP)**.
-
-See the [GSA Vulnerability Disclosure Policy](https://gsa.gov/vulnerability-disclosure-policy) for details including:
+are covered by the **GSA Vulnerability Disclosure Policy**. See the [policy page](https://gsa.gov/vulnerability-disclosure-policy) for details including:
 
 * GSA's coordinated disclosure policy.
 * Information on how you may conduct security research on GSA developed
@@ -12,7 +10,7 @@ See the [GSA Vulnerability Disclosure Policy](https://gsa.gov/vulnerability-disc
 
 ## Reporting a Vulnerability
 
-Security issues should be reported via GitHub [private vulnerability reporting](https://docs.github.com/en/code-security/security-advisories/guidance-on-reporting-and-writing-information-about-vulnerabilities/privately-reporting-a-security-vulnerability#privately-reporting-a-security-vulnerability) (requires a GitHub account) or by sending an email to dap@gsa.gov.
+Security issues should be reported via GitHub [private vulnerability reporting](https://docs.github.com/en/code-security/security-advisories/guidance-on-reporting-and-writing-information-about-vulnerabilities/privately-reporting-a-security-vulnerability#privately-reporting-a-security-vulnerability) (requires a GitHub account) or by sending an email to <dap@gsa.gov>.
 
 Security issues may also be reported to the GSA Vulnerability Disclosure Program, following instructions in the policy linked above. However, we ask that you report directly to us as well, to ensure that the issue will be reviewed quickly.
 
@@ -25,5 +23,5 @@ Please note that only the most recent major version of the DAP code is supported
 | 8.x   | :white_check_mark: |
 | < 8.0 | :x:                |
 
-When using this code or reporting vulnerabilities please only use supported
+When using this code or reporting vulnerabilities, please only use supported
 versions.


### PR DESCRIPTION
~~Copied the boilerplate `SECURITY.md` file from the [Allstar repo](https://github.com/GSA-TTS/.allstar/blob/main/SECURITY.md). I omitted the section about bug bounties since DAP doesn't participate in the bug bounty program. Although, that wouldn't be a bad idea...~~

I decided not to follow the Allstar version's recommendation to route reporting through GSA's VDP. As far as I can tell, GSA will not give TTS development teams access to manage reports for their own properties in HackerOne. Also, I sent an email to gsa-vulnerability-reports@gsa.gov and haven't received a response. The GSA VDP feels like a black hole to me. If it proves itself otherwise, I'll consider updating this policy.

Fixes #139.