### PR TITLE
Add web-vitals dependency

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -8,6 +8,9 @@
       "name": "digital-analytics-program",
       "version": "4.1.0",
       "license": "ISC",
+      "dependencies": {
+        "web-vitals": "^4.2.4"
+      },
       "devDependencies": {
         "@cucumber/cucumber": "^11.0.0",
         "chai": "^5.1.1",
@@ -3687,6 +3690,12 @@
         "spdx-correct": "^3.0.0",
         "spdx-expression-parse": "^3.0.0"
       }
+    },
+    "node_modules/web-vitals": {
+      "version": "4.2.4",
+      "resolved": "https://registry.npmjs.org/web-vitals/-/web-vitals-4.2.4.tgz",
+      "integrity": "sha512-r4DIlprAGwJ7YM11VZp4R884m0Vmgr6EAKe3P+kO0PPj3Unqyvv59rczf6UiGcb9Z8QxZVcqKNwv/g0WNdWwsw==",
+      "license": "Apache-2.0"
     },
     "node_modules/which": {
       "version": "2.0.2",

--- a/package.json
+++ b/package.json
@@ -27,5 +27,8 @@
     "eslint-plugin-compat": "^6.0.0",
     "eslint-plugin-jsdoc": "^50.2.2",
     "puppeteer": "^23.3.0"
+  },
+  "dependencies": {
+    "web-vitals": "^4.2.4"
   }
 }


### PR DESCRIPTION
Related to https://github.com/digital-analytics-program/gov-wide-code/pull/153.

This repo doesn't have a build process yet so there's no obvious functional reason to add this dependency. However, adding it:
1. Documents which version of web-vitals we're using.
2. Enables security-related dependency scanning for the library.