### PR TITLE
Potential fix for code scanning alert no. 18: Workflow does not contain permissions

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -5,6 +5,8 @@ on:
 jobs:
   lint:
     runs-on: ubuntu-latest
+    permissions:
+      contents: read
     steps:
       - name: Code Checkout
         uses: actions/checkout@v4


### PR DESCRIPTION
Potential fix for [https://github.com/digital-analytics-program/gov-wide-code/security/code-scanning/18](https://github.com/digital-analytics-program/gov-wide-code/security/code-scanning/18)

In general, to fix this problem you should add a `permissions` block either at the root of the workflow (to apply to all jobs) or within the specific job that CodeQL flagged. The block should grant only the minimal scopes needed; for a simple lint job that just checks out code and runs `npm` commands, `contents: read` is typically sufficient.

For this specific workflow (`.github/workflows/ci.yml`), the minimal and least-invasive change is to add a `permissions` stanza under the `lint` job, right alongside `runs-on`. This keeps the change tightly scoped while not altering any existing steps or behavior. The result will look like:

```yaml
jobs:
  lint:
    runs-on: ubuntu-latest
    permissions:
      contents: read
    steps:
      ...
```

No additional imports, methods, or definitions are needed, since `permissions` is a standard GitHub Actions workflow key. The only file to change is `.github/workflows/ci.yml`, and the only region to update is the `lint` job header around line 7.


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
