### PR TITLE
Add tests for pii redaction

### DIFF
--- a/features/configuration.feature
+++ b/features/configuration.feature
@@ -7,7 +7,7 @@ Feature: A site can load the DAP code with varying levels of customization
     Given DAP is configured for agency "HHS"
     And DAP is configured for subagency "CDC"
     When I load the test site
-    Then DAP will set custom dimensions
+    Then DAP will set custom dimensions for the DAP property
       | agency | HHS |
       | subagency | CDC |
 
@@ -16,7 +16,7 @@ Feature: A site can load the DAP code with varying levels of customization
     And DAP is configured with site topic "Analytics"
     And DAP is configured with site platform "Cloud.gov"
     When I load the test site
-    Then DAP will set custom dimensions
+    Then DAP will set custom dimensions for the DAP property
     | agency | GSA |
     | site_topic | analytics |
     | site_platform | cloud.gov |

--- a/features/pii_redaction.feature
+++ b/features/pii_redaction.feature
@@ -1,0 +1,66 @@
+Feature: DAP redacts PII
+
+  Background:
+    Given I load an empty browser
+    And DAP is configured for agency "GSA"
+
+  Scenario: Email addresses are redacted from event parameters
+    When I load the test site
+    And I execute script "window.gas4('error', {type: 'form', url: 'user@example.com'})"
+    Then a "error" event is sent to DAP with parameters
+      | type | form             |
+      | url  | [REDACTED_EMAIL] |
+
+  Scenario: SSNs are redacted from event parameters
+    When I load the test site
+    And I execute script "window.gas4('error', {type: 'form', url: '123-45-6789'})"
+    Then a "error" event is sent to DAP with parameters
+      | type | form           |
+      | url  | [REDACTED_SSN] |
+
+  Scenario: Phone numbers are redacted from event parameters
+    When I load the test site
+    And I execute script "window.gas4('error', {type: 'form', url: '202-555-1234'})"
+    Then a "error" event is sent to DAP with parameters
+      | type | form           |
+      | url  | [REDACTED_TEL] |
+
+  Scenario: Dates of birth are redacted from event parameters when labeled with dob=
+    When I load the test site
+    And I execute script "window.gas4('error', {type: 'form', url: 'dob=1990-01-15'})"
+    Then a "error" event is sent to DAP with parameters
+      | type | form           |
+      | url  | [REDACTED_DOB] |
+
+  Scenario: Passwords are redacted from event parameters when labeled with password=
+    When I load the test site
+    And I execute script "window.gas4('error', {type: 'form', url: 'password=mysecret123'})"
+    Then a "error" event is sent to DAP with parameters
+      | type | form                |
+      | url  | [REDACTED_PASSWORD] |
+
+  Scenario: ZIP codes are redacted from event parameters when labeled with zip=
+    When I load the test site
+    And I execute script "window.gas4('error', {type: 'form', url: 'zip=20001'})"
+    Then a "error" event is sent to DAP with parameters
+      | type | form           |
+      | url  | [REDACTED_ZIP] |
+
+  Scenario: Non-PII data is not redacted from event parameters
+    When I load the test site
+    And I execute script "window.gas4('error', {type: 'validation', url: '/contact/submit'})"
+    Then a "error" event is sent to DAP with parameters
+      | type | validation      |
+      | url  | /contact/submit |
+
+  Scenario: PII redaction applies to parameters in config calls
+    Given the page URL has query parameter "search" set to "user@example.com"
+    When I load the test site
+    Then the config call for the DAP property has "page_location" containing "[REDACTED_EMAIL]"
+
+  Scenario: PII redaction applies to automatically collected events
+    Given the page URL has query parameter "search" set to "user@example.com"
+    And I set the browser to intercept outbound requests
+    When I load the test site
+    And I wait 5 seconds
+    Then there is a GA4 request reporting event "page_view" with parameter "dl" containing "[REDACTED_EMAIL]"

--- a/features/support/step_definitions/browser_steps.js
+++ b/features/support/step_definitions/browser_steps.js
@@ -57,6 +57,21 @@ Then("there is a GA4 request", function () {
   expect(ga4Request).to.exist;
 });
 
+Then("there is a GA4 request reporting event {string} with parameter {string} containing {string}", function (eventName, paramName, value) {
+  const ga4Request = this.requests.find(request => {
+    try {
+      const url = new URL(request.url);
+      return url.host === "www.google-analytics.com"
+        && url.pathname === "/g/collect"
+        && url.searchParams.has("en", eventName)
+        && url.searchParams.has(paramName) && url.searchParams.get(paramName).includes(value);
+    } catch (e) {
+      return false;
+    }
+  });
+  expect(ga4Request).to.exist;
+});
+
 Then("there are no unexpected requests", function () {
   const requestURLs = this.requests.map((request) => {
     return (new URL(request.url)).host;

--- a/features/support/step_definitions/dataLayer_steps.js
+++ b/features/support/step_definitions/dataLayer_steps.js
@@ -2,12 +2,17 @@ import { Then } from "@cucumber/cucumber";
 import * as chai from 'chai'
 const expect = chai.expect;
 
-Then("DAP will set custom dimensions", async function (table) {
+Then("the config call for the DAP property has {string} containing {string}", async function (key, substring) {
   const configCommand = await this.page.evaluate(() => {
-    return window.dataLayer.find(item => item[0] === 'config');
+    return window.dataLayer.find(item => item[0] === 'config' && item[1] === "G-9TNNMGP8WJ");
   });
-  expect(configCommand["0"]).to.equal("config");
-  expect(configCommand["1"]).to.equal("G-9TNNMGP8WJ");
+  expect(configCommand["2"][key]).to.include(substring);
+});
+
+Then("DAP will set custom dimensions for the DAP property", async function (table) {
+  const configCommand = await this.page.evaluate(() => {
+    return window.dataLayer.find(item => item[0] === 'config' && item[1] === "G-9TNNMGP8WJ");
+  });
   expect(configCommand["2"]).to.include(table.rowsHash());
 });
 
@@ -39,4 +44,12 @@ Then("the file download is not reported to DAP", async function () {
     return window.dataLayer.find(item => item[0] === 'event' && item[1] === 'file_download');
   });
   expect(event).to.be.undefined;
+});
+
+Then("a {string} event is sent to DAP with parameters", async function (eventName, table) {
+  const event = await this.page.evaluate((name) => {
+    return window.dataLayer.find(item => item[0] === 'event' && item[1] === name);
+  }, eventName);
+  expect(event).to.exist;
+  expect(event["2"]).to.include(table.rowsHash());
 });

--- a/features/support/step_definitions/interaction_steps.js
+++ b/features/support/step_definitions/interaction_steps.js
@@ -1,5 +1,9 @@
 import { When } from "@cucumber/cucumber";
 
+When("I execute script {string}", async function (script) {
+  await this.page.evaluate((s) => eval(s), script);
+});
+
 When("I click on a file to download it", async function () {
   await this.page.locator('#internalDownload').click();
 });

--- a/features/support/step_definitions/loading_steps.js
+++ b/features/support/step_definitions/loading_steps.js
@@ -26,6 +26,11 @@ Given("DAP is configured with autotracking disabled", function () {
   this.dapConfig.autotracker = false;
 });
 
+Given("the page URL has query parameter {string} set to {string}", function (key, value) {
+  this.pageParams = this.pageParams || {};
+  this.pageParams[key] = value;
+});
+
 When("I load the test site", async function () {
-  await this.page.goto(`http://localhost:8080?${this.dapConfig.toQueryParams()}`);
+  await this.page.goto(`http://localhost:8080?${this.dapConfig.toQueryParams()}&${new URLSearchParams(this.pageParams).toString()}`);
 });


### PR DESCRIPTION
A few integration tests for PII redaction, mostly testing that redaction is applied in the correct circumstances. These are not intended to fully exercise the redaction algorithms. Once these integration tests are in place, I'd like to refactor the redaction function so it can be unit tested and build a more complete unit test suite.

- PII redaction is applied to the event parameters in a `gtag('event', '<event_name>', {<event_params>})` call. Tests for email, SSN, phone number, DOB, and password redaction.
- PII redaction is applied to the additional config info in a `gtag('config', '<TARGET_ID>', {<additional_config_info>})` call.
- PII redaction also applies to GA4 automatically collected events, which DAP implements by adding a PII-redacting wrapper to the `window.navigator.sendBeacon` call.